### PR TITLE
Add reverse cycle mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Home Assistant - Dual Mode Generic Thermostat
 
-> Special thanks to [shandoosheri](https://community.home-assistant.io/t/heat-cool-generic-thermostat/76443) for getting this to work on older versions of Home Assistant, which gave me an easy blueprint to follow. And thanks [@kevinvincent](https://github.com/kevinvincent) for writing a nice `custom_component` readme for me to fork. 
+> Special thanks to [shandoosheri](https://community.home-assistant.io/t/heat-cool-generic-thermostat/76443) for getting this to work on older versions of Home Assistant, which gave me an easy blueprint to follow. And thanks [@kevinvincent](https://github.com/kevinvincent) for writing a nice `custom_component` readme for me to fork.
 
-This component is a straightfoward fork of the mainline `generic_thermostat`. 
+This component is a straightfoward fork of the mainline `generic_thermostat`.
 
 ## Installation (HACS) - Recommended
 0. Have [HACS](https://custom-components.github.io/hacs/installation/manual/) installed, this will allow you to easily update
@@ -26,23 +26,25 @@ climate:
     heater: switch.heater
     cooler: switch.fan
     target_sensor: sensor.my_temp_sensor
+    reverse_cycle: true
 ```
 
-The component shares the same configuration variables as the standard `generic_thermostat`, with two exceptions:
+The component shares the same configuration variables as the standard `generic_thermostat`, with three exceptions:
 * A `cooler` variable has been added where you can specify the `entity_id` of your switch for a cooling unit (AC, fan, etc).
-* The `ac_mode` variable has been removed, since it makes no sense for this use case. 
+* If the cooling and heating unit are the same device (e.g. a reverse cycle air conditioner) setting `reverse_cycle` to `true` will ensure the device isn't switched off entirely when switching modes
+* The `ac_mode` variable has been removed, since it makes no sense for this use case.
 
 Refer to the [Generic Thermostat documentation](https://www.home-assistant.io/components/generic_thermostat/) for details on the rest of the variables. This component doesn't change their functionality.
 
 ## Behavior
 
-* The thermostat will follow standard mode-based behavior: if set to "cool," the only switch which can be activated is the `cooler`. This means if the target temperature is higher than the actual temperateure, the `heater` will _not_ start. Vice versa is also true. 
+* The thermostat will follow standard mode-based behavior: if set to "cool," the only switch which can be activated is the `cooler`. This means if the target temperature is higher than the actual temperateure, the `heater` will _not_ start. Vice versa is also true.
 
-* Keepalive logic has been updated to be aware of the mode in current use, so should function as expected. 
+* Keepalive logic has been updated to be aware of the mode in current use, so should function as expected.
 
-* By default, the component will restore the last state of the thermostat prior to a restart. 
+* By default, the component will restore the last state of the thermostat prior to a restart.
 
-* While `heater`/`cooler` are documented to be `switch`es, they can also be `input_boolean`s if necessary. 
+* While `heater`/`cooler` are documented to be `switch`es, they can also be `input_boolean`s if necessary.
 
 
 ## Reporting an Issue

--- a/custom_components/dualmode_generic/climate.py
+++ b/custom_components/dualmode_generic/climate.py
@@ -78,7 +78,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_MIN_DUR): vol.All(cv.time_period, cv.positive_timedelta),
         vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_REVERSE_CYCLE): cv.boolean,
+        vol.Optional(CONF_REVERSE_CYCLE, default=False): cv.boolean,
         vol.Optional(CONF_COLD_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
         vol.Optional(CONF_HOT_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
         vol.Optional(CONF_TARGET_TEMP): vol.Coerce(float),


### PR DESCRIPTION
- If both the heater and cooling devices are the same physical device (e.g. a reverse cycle air conditioner) then a reverse cycle mode was needed to prevent the device from switching off when changing temperature or other state.
- Also fixed a problem where the "long enough" calculation was ignoring the cooling entity state.

This worked on v0.99 of HA. ~~However, I've just upgraded my installation to 108, and finding that the thermostat doesn't switch on until I change the temperature state.~~  This may have actually been due to the dodgy way I was switching on my air-con - need to investigate further 🤔 

There does seem to be some recent fixes to the generic thermostat integration (https://github.com/home-assistant/core/commits/dev/homeassistant/components/generic_thermostat/climate.py) so will incorporate those into another PR down the track.

Thanks for the initial work on this integration! Has been super useful so far. We should look to get it into HACS at some point.