### PR TITLE
Heat/Cool mode with Temperature range and humidity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,25 @@ climate:
     reverse_cycle: true
 ```
 
-The component shares the same configuration variables as the standard `generic_thermostat`, with three exceptions:
+The component shares the same configuration variables as the standard `generic_thermostat`, with some exceptions:
 * A `cooler` variable has been added where you can specify the `entity_id` of your switch for a cooling unit (AC, fan, etc).
 * If the cooling and heating unit are the same device (e.g. a reverse cycle air conditioner) setting `reverse_cycle` to `true` will ensure the device isn't switched off entirely when switching modes
 * The `ac_mode` variable has been removed, since it makes no sense for this use case.
+* `target_temp_high` and `target_temp_low` set the default value for the upper and lower setting for temperature range when in `HEAT_COOL` mode
 
 Refer to the [Generic Thermostat documentation](https://www.home-assistant.io/components/generic_thermostat/) for details on the rest of the variables. This component doesn't change their functionality.
 
 ## Behavior
 
-* The thermostat will follow standard mode-based behavior: if set to "cool," the only switch which can be activated is the `cooler`. This means if the target temperature is higher than the actual temperateure, the `heater` will _not_ start. Vice versa is also true.
+* For `HEAT` or `COOL` modes, the thermostat will follow standard mode-based behavior: if set to "cool," the only switch which can be activated is the `cooler`. This means if the target temperature is higher than the actual temperateure, the `heater` will _not_ start. Vice versa is also true.
+
+* For `HEAT_COOL` mode, the thermostat will attempt to maintain the temperature within the set range, turning on the configured heater when the temperature drops below the bottom of the range by `cold_tolerance` and turning on the configured cooler when the temperature rises above the top of the set range by the `hot_tolerance` amount. When the measured temperature is within the configured range by `(hot|cold)_tolerance` the thermostat will transition to idle mode and both heater and cooler will be turned off.
 
 * Keepalive logic has been updated to be aware of the mode in current use, so should function as expected.
 
 * By default, the component will restore the last state of the thermostat prior to a restart.
 
-* While `heater`/`cooler` are documented to be `switch`es, they can also be `input_boolean`s if necessary.
+* While `heater`/`cooler` are documented to be `switch`es, they can also be `input_boolean`s if necessary. Note that these are assumed to be exclusively for the use of the thermostat - the thermostat will report its mode and change its behaviour based on the position of these switches.
 
 
 ## Reporting an Issue

--- a/custom_components/dualmode_generic/__init__.py
+++ b/custom_components/dualmode_generic/__init__.py
@@ -1,0 +1,4 @@
+"""The dualmode_generic thermostat component."""
+
+DOMAIN = "dualmode_generic"
+PLATFORMS = ["climate"]

--- a/custom_components/dualmode_generic/services.yaml
+++ b/custom_components/dualmode_generic/services.yaml
@@ -1,0 +1,2 @@
+reload:
+  description: Reload all dualmode_generic thermostat entities.


### PR DESCRIPTION
This PR adds heat/cool operation mode for dualmode generic thermostats with temperature range support.

This allows setting the desired temp range and then forgetting about it - no more switching between heat and cool.

I've been running it for months now and it seems to work pretty well. Thanks for your work on dualmode, it's exactly what people with heat pumps need.

There are a couple of metadata updates to allow things like restarting the plugin without having to restart HA, and there is also the beginnings of humidity support, with support for a humidity sensor, although I haven't yet had the time to make it do anything with the data.