### PR TITLE
Remove unused argument to the `_async_startup` method

### DIFF
--- a/custom_components/dualmode_generic/climate.py
+++ b/custom_components/dualmode_generic/climate.py
@@ -380,7 +380,7 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
             )
 
         @callback
-        def _async_startup(event):
+        def _async_startup():
             """Init on startup."""
             sensor_state = self.hass.states.get(self.sensor_entity_id)
             if sensor_state and sensor_state.state not in (


### PR DESCRIPTION
While trying to configure the integration, I was using the `YAML configuration reloading` functionality to select `DUALMODE_GENERIC` while trying different configurations in my main `configuration.yaml` file. Whenever I tried to do the targeted reload, I was met with a non-functional climate card and the following in my error log:

### Error Logs
```
Logger: homeassistant.components.climate
Source: custom_components/dualmode_generic/climate.py:401 
Integration: Climate (documentation, issues) 
First occurred: 9:41:30 PM (2 occurrences) 
Last logged: 9:41:30 PM

Error adding entities for domain climate with platform dualmode_generic
Error while setting up dualmode_generic platform for climate
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 587, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 681, in add_to_platform_finish
    await self.async_added_to_hass()
  File "/config/custom_components/dualmode_generic/climate.py", line 401, in async_added_to_hass
    _async_startup()
TypeError: _async_startup() missing 1 required positional argument: 'event'
```

Can't say I'm terribly familiar with python, but I can read an error log and can see that the variable isn't being used. By changing the signature from `def _async_startup(event):` to `def _async_startup():`, the error went away and I have a new awesome and fully functional dual mode climate control 😁 