### PR TITLE
Check temperature range instead of target temperature when in heat_cool mode

### DIFF
--- a/custom_components/dualmode_generic/climate.py
+++ b/custom_components/dualmode_generic/climate.py
@@ -735,7 +735,7 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
     async def _async_control_heating(self, time=None, force=False):
         """Check if we need to turn heating on or off."""
         async with self._temp_lock:
-            if not self._active and None not in (self._cur_temp, self._target_temp):
+            if (not self._active and self._cur_temp is not None and ((self._hvac_mode != HVAC_MODE_HEAT_COOL and self._target_temp is not None) or (self._hvac_mode == HVAC_MODE_HEAT_COOL and None not in (self._target_temp_low, self._target_temp_high)))):
                 self._active = True
                 _LOGGER.info(
                     "Obtained current and target temperature. "


### PR DESCRIPTION
The PR I completed earlier introduced an issue since I missed removing the check on the target_temp when controlling the heater/cooler entities. Now that the target_temp has been unset for heat_cool mode, we need to instead check target_temp_low and target_temp_high.

This is a PR to fix this issue. Sorry about that!