### PR TITLE
Hotfix/UI improvements

### DIFF
--- a/custom_components/dualmode_generic/climate.py
+++ b/custom_components/dualmode_generic/climate.py
@@ -592,7 +592,17 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
 
     @property
     def target_temperature(self):
-        """Return the temperature we try to reach."""
+        """
+        Return the temperature we try to reach.
+
+        We return None in modes where we either need high and low target temperatures
+        or when we are in fan only mode with neutral fan behavior. As in such a case the single target temperature
+        is not needed and only clutters the UI.
+        """
+        if self._hvac_mode == HVAC_MODE_FAN_ONLY and self.fan_behavior == FAN_MODE_NEUTRAL:
+            return None
+        if self._hvac_mode == HVAC_MODE_DRY and self.dryer_behavior == DRYER_MODE_NEUTRAL:
+            return None
         if self._hvac_mode != HVAC_MODE_HEAT_COOL:
             return self._target_temp
         else:
@@ -600,13 +610,27 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
 
     @property
     def target_temperature_high(self):
-        """Return the upper temperature we try to reach when in range mode."""
-        return self._target_temp_high
+        """
+        Return the upper temperature we try to reach when in range mode.
+
+        We return None in modes where we don't need high and low target temperatures.
+        """
+        if self._hvac_mode == HVAC_MODE_HEAT_COOL:
+            return self._target_temp_high
+        else:
+            return None
 
     @property
     def target_temperature_low(self):
-        """Return the lower temperature we try to reach when in range mode."""
-        return self._target_temp_low
+        """
+        Return the lower temperature we try to reach when in range mode.
+
+        We return None in modes where we don't need high and low target temperatures.
+        """
+        if self._hvac_mode == HVAC_MODE_HEAT_COOL:
+            return self._target_temp_low
+        else:
+            return None
 
     @property
     def hvac_modes(self):

--- a/custom_components/dualmode_generic/climate.py
+++ b/custom_components/dualmode_generic/climate.py
@@ -272,6 +272,7 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
         self.heater_entity_id = heater_entity_id
         self.cooler_entity_id = cooler_entity_id
         self.sensor_entity_id = sensor_entity_id
+        self.humidity_sensor_entity_id = humidity_sensor_entity_id
         self.fan_entity_id = fan_entity_id
         self.fan_behavior = fan_behavior
         self.dryer_entity_id = dryer_entity_id
@@ -352,7 +353,6 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
         self._away_temp_heater = away_temp_heater
         self._away_temp_cooler = away_temp_cooler
         self._is_away = False
-        self.humidity_sensor_entity_id = humidity_sensor_entity_id
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -424,7 +424,7 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
                         STATE_UNAVAILABLE,
                         STATE_UNKNOWN,
                 ):
-                    self._async_update_temp(humidity_sensor_state)
+                    self._async_update_humidity(humidity_sensor_state)
 
         if self.hass.state == CoreState.running:
             _async_startup()


### PR DESCRIPTION
This PR expands upon the clean-up effort of #65 (which should be merged first)

I added the following fixes:
- Proper support for `climate.turn_on` and `climate.turn_off` (instead of just suppressing the deprecation warning)
- Fixed incorrect updating of `current_temperature` with value of humidity sensor (maybe we can add some kind of hygrostat control when in dry-mode)
- I was inspired by [#64](https://github.com/zacs/ha-dualmodegeneric/pull/64) and the way it hid the `TARGET_TEMPERATURE`-Slider when running in `HEAT_COOL_MODE`. So I expanded upon this by also implementing similar logic for `TARGET_HIGH_TEMPERATURE` and `TARGET_LOW_TEMPERATURE`

Fixes:
- #56
