### PR TITLE
Fix: HVAC Action Display for Reverse Cycle Units in Heat/Cool Mode

### DIFF
--- a/custom_components/dualmode_generic/climate.py
+++ b/custom_components/dualmode_generic/climate.py
@@ -546,12 +546,23 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
         elif self._hvac_mode == HVAC_MODE_DRY:
             return CURRENT_HVAC_DRY
         elif self._hvac_mode == HVAC_MODE_HEAT_COOL:
-            if self.hass.states.is_state(self.heater_entity_id, STATE_ON):
-                return CURRENT_HVAC_HEAT
-            elif self.hass.states.is_state(self.cooler_entity_id, STATE_ON):
-                return CURRENT_HVAC_COOL
+            # Check if heater and cooler are the same entity (reverse cycle)
+            if self.heater_entity_id == self.cooler_entity_id:
+                # For reverse cycle, determine action based on current temperature
+                if self._cur_temp >= self._target_temp_high + self._hot_tolerance:
+                    return CURRENT_HVAC_COOL
+                elif self._cur_temp <= self._target_temp_low - self._cold_tolerance:
+                    return CURRENT_HVAC_HEAT
+                else:
+                    return CURRENT_HVAC_IDLE
             else:
-                return CURRENT_HVAC_IDLE
+                # Original logic for separate heater/cooler
+                if self.hass.states.is_state(self.heater_entity_id, STATE_ON):
+                    return CURRENT_HVAC_HEAT
+                elif self.hass.states.is_state(self.cooler_entity_id, STATE_ON):
+                    return CURRENT_HVAC_COOL
+                else:
+                    return CURRENT_HVAC_IDLE
         else:
             return CURRENT_HVAC_IDLE
 


### PR DESCRIPTION
# Fix: HVAC Action Display for Reverse Cycle Units in Heat/Cool Mode

## Problem

When using a reverse cycle air conditioner (same entity for both `heater` and `cooler`) in `HVAC_MODE_HEAT_COOL`, the `hvac_action` property incorrectly displays "Heating" even when the system should be cooling.

### Root Cause

In the `hvac_action` property (lines 548-554), when in `HVAC_MODE_HEAT_COOL`, the code checks which entity is ON to determine the display state:

```python
elif self._hvac_mode == HVAC_MODE_HEAT_COOL:
    if self.hass.states.is_state(self.heater_entity_id, STATE_ON):
        return CURRENT_HVAC_HEAT
    elif self.hass.states.is_state(self.cooler_entity_id, STATE_ON):
        return CURRENT_HVAC_COOL
```

For reverse cycle units where `heater_entity_id == cooler_entity_id`, this logic fails because:
1. Both entities point to the same physical device
2. The check for `heater_entity_id` happens first
3. When the device is ON (regardless of whether it's heating or cooling), it always returns `CURRENT_HVAC_HEAT`

### User Impact

Users with reverse cycle air conditioners see incorrect status in the UI:
- Current temp: 26°C
- Target range: 23.5°C - 24.5°C  
- Expected display: "Cooling"
- Actual display: "Heating" ❌

The underlying control logic works correctly (it does activate cooling), but the UI feedback is wrong, leading to user confusion.

## Solution

When `heater_entity_id == cooler_entity_id` (indicating a reverse cycle unit), determine the HVAC action based on the current temperature relative to the target range:

- If `current_temp >= target_temp_high + hot_tolerance` → Cooling
- If `current_temp <= target_temp_low - cold_tolerance` → Heating
- Otherwise → Idle

This approach:
- ✅ Is simpler and more maintainable than tracking state
- ✅ Accurately reflects what the system should be doing
- ✅ Works for both reverse cycle and traditional split systems
- ✅ Requires minimal code changes

## Changes Made

Modified the `hvac_action` property in `climate.py` to detect reverse cycle units and use temperature-based logic:

```python
elif self._hvac_mode == HVAC_MODE_HEAT_COOL:
    # Check if heater and cooler are the same entity (reverse cycle)
    if self.heater_entity_id == self.cooler_entity_id:
        # For reverse cycle, determine action based on current temperature
        if self._cur_temp >= self._target_temp_high + self._hot_tolerance:
            return CURRENT_HVAC_COOL
        elif self._cur_temp <= self._target_temp_low - self._cold_tolerance:
            return CURRENT_HVAC_HEAT
        else:
            return CURRENT_HVAC_IDLE
    else:
        # Original logic for separate heater/cooler
        if self.hass.states.is_state(self.heater_entity_id, STATE_ON):
            return CURRENT_HVAC_HEAT
        elif self.hass.states.is_state(self.cooler_entity_id, STATE_ON):
            return CURRENT_HVAC_COOL
        else:
            return CURRENT_HVAC_IDLE
```

## Testing

### Test Configuration
```yaml
- platform: dualmode_generic
  name: Master Bedroom
  unique_id: climate.master_bedroom
  heater: input_boolean.master_bedroom_aircon
  cooler: input_boolean.master_bedroom_aircon  # Same entity = reverse cycle
  target_sensor: sensor.master_bedroom_temperature
  enable_heat_cool: True
  min_temp: 16
  max_temp: 30
  target_temp: 23
  precision: 0.1
  hot_tolerance: 0.5
  cold_tolerance: 0.5
  min_cycle_duration:
    minutes: 5
  target_temp_step: 0.5
```

### Test Scenarios

**Scenario 1: Cooling Required**
- Current temp: 26°C
- Target range: 23.5°C - 24.5°C
- Expected: Display shows "Cooling" ✅
- Before fix: Displayed "Heating" ❌

**Scenario 2: Heating Required**  
- Current temp: 22°C
- Target range: 23.5°C - 24.5°C
- Expected: Display shows "Heating" ✅
- Works correctly both before and after

**Scenario 3: Traditional Split System (Different Entities)**
- Uses separate heater and cooler entities
- Expected: Original behavior preserved ✅
- No regression

## Backwards Compatibility

✅ Fully backwards compatible
- Existing configurations with separate heater/cooler entities continue to use original logic
- Only affects reverse cycle configurations (same entity for both)
- No configuration changes required

## Related Issues

This fix addresses the scenario described in [relevant issue number if one exists].

