### PR TITLE
Adding water probe sensor and UI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ climate:
     min_cycle_duration:
         minutes: 20
     consent_entity: calendar.schedule_time
+    water_sensor: sensor.water_supply_temperature
+    water_setpoint_heat: 30
+    water_setpoint_cool: 15
+    water_setpoint_heat_entity: input_number.water_setpoint_heat
+    water_setpoint_cool_entity: input_number.water_setpoint_cool
+    water_tolerance: 1.0
 ```
 
 ### Possible values for *_behavior
@@ -90,6 +96,59 @@ Refer to the [Generic Thermostat documentation](https://www.home-assistant.io/co
   the thermostat will report its mode and change its behaviour based on the position of these switches.
 
 * `consent_entity`is an optional entity (e.g., `binary_sensor`, `input_boolean`, or `calendar`) that acts as an additional control for the thermostat. When the entity is in the "on" state (or equivalent, such as `true` for calendars), the thermostat operates normally. When the entity is "off" or unavailable, all devices controlled by the thermostat (heater, cooler, dryer, fan) are turned off, but the thermostat retains its previous HVAC mode setting ("keep previous mode"). This allows you to schedule thermostat operation using calendar entities or other logic, without needing separate automations.
+
+## Water Temperature Guard
+
+The thermostat supports an optional **water supply temperature guard** that prevents the heater or cooler from activating unless the water circuit has reached the required temperature. This is useful for hydronic systems (e.g., radiant floor heating, fan coils) where the equipment should only run when the boiler or chiller has prepared the water.
+
+### Configuration
+
+| Key | Required | Description |
+|---|---|---|
+| `water_sensor` | Yes (to enable guard) | Entity ID of the sensor measuring the water supply temperature |
+| `water_setpoint_heat` | Optional | Fixed water temperature threshold for heating (float, °C or °F). The heater starts only when water temp ≥ this value |
+| `water_setpoint_cool` | Optional | Fixed water temperature threshold for cooling (float, °C or °F). The cooler starts only when water temp ≤ this value |
+| `water_setpoint_heat_entity` | Optional | Entity whose state provides the heating threshold dynamically (e.g. `input_number`) — takes priority over `water_setpoint_heat` |
+| `water_setpoint_cool_entity` | Optional | Entity whose state provides the cooling threshold dynamically (e.g. `input_number`) — takes priority over `water_setpoint_cool` |
+| `water_tolerance` | Optional (default: `0.3`) | Dead-band tolerance applied to the water setpoint checks |
+
+At least one setpoint (fixed or entity) must be provided for the relevant mode together with `water_sensor` for the guard to function. If no setpoint is configured for a specific mode, the guard is satisfied and operation proceeds normally for that mode.
+
+### Behavior
+
+* **Heating mode** (`heat`, `fan_only` with `fan_behavior: heater`, `dry` with `dryer_behavior: heater`): the device starts only when `water_temp >= water_setpoint_heat - tolerance`. Example: `water_setpoint_heat: 30` → the heater only runs if the water supply is at least 30°C (the boiler has heated the water). If the water is not hot enough, all devices are turned off and the action reports `idle`.
+* **Cooling mode** (`cool`, `fan_only` with `fan_behavior: cooler`, `dry` with `dryer_behavior: cooler`): the device starts only when `water_temp <= water_setpoint_cool + tolerance`. Example: `water_setpoint_cool: 15` → the cooler only runs if the water supply is at most 15°C (the chiller has cooled the water). If the water is not cold enough, all devices are turned off and the action reports `idle`.
+* **`HEAT_COOL` mode**: the guard is applied independently per device. The heater will not start if the water is not hot enough (checked against `water_setpoint_heat`), and the cooler will not start if the water is not cold enough (checked against `water_setpoint_cool`). The two can operate independently.
+* When the water temperature crosses the threshold (because of a sensor update or a setpoint entity change), `_async_control_heating` is triggered automatically — the device will start or stop without any additional automation needed.
+
+### Additional State Attributes
+
+When `water_sensor` is configured, the following attributes are added to the thermostat entity:
+
+| Attribute | Description |
+|---|---|
+| `water_temperature` | Current water supply temperature from the sensor |
+| `water_setpoint_heat` | The active heating setpoint (entity value if configured, otherwise fixed value) |
+| `water_setpoint_cool` | The active cooling setpoint (entity value if configured, otherwise fixed value) |
+| `water_guard_active` | `true` when the guard is blocking operation |
+
+### Example Config
+
+```yaml
+climate:
+  - platform: dualmode_generic
+    name: Floor Heating & Cooling
+    heater: switch.floor_heating_valve
+    cooler: switch.floor_cooling_valve
+    target_sensor: sensor.room_temperature
+    enable_heat_cool: True
+    water_sensor: sensor.water_supply_temp
+    water_setpoint_heat: 30
+    water_setpoint_cool: 15
+    water_setpoint_heat_entity: input_number.water_setpoint_winter
+    water_setpoint_cool_entity: input_number.water_setpoint_summer
+    water_tolerance: 1.5
+```
 
 
 ## Reporting an Issue

--- a/custom_components/dualmode_generic/__init__.py
+++ b/custom_components/dualmode_generic/__init__.py
@@ -1,4 +1,29 @@
 """The dualmode_generic thermostat component."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 DOMAIN = "dualmode_generic"
 PLATFORMS = ["climate"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the dualmode_generic component (YAML-based legacy support)."""
+    # Legacy YAML platform setup is handled by climate.py async_setup_platform
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up dualmode_generic from a config entry (UI-based)."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update — reload the entry to apply changes."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/dualmode_generic/climate.py
+++ b/custom_components/dualmode_generic/climate.py
@@ -97,6 +97,12 @@ CONF_REVERSE_CYCLE = "reverse_cycle"
 CONF_SENSOR = "target_sensor"
 CONF_HUMIDITY_SENSOR = "target_humidity_sensor"
 CONF_CONSENT_ENTITY = "consent_entity"  # Optional entity to control thermostat enable/disable
+CONF_WATER_SENSOR = "water_sensor"  # Optional water supply temperature sensor
+CONF_WATER_SETPOINT_HEAT = "water_setpoint_heat"  # Fixed water temp setpoint for heating (water must be >= this)
+CONF_WATER_SETPOINT_COOL = "water_setpoint_cool"  # Fixed water temp setpoint for cooling (water must be <= this)
+CONF_WATER_SETPOINT_HEAT_ENTITY = "water_setpoint_heat_entity"  # Dynamic water setpoint entity for heating
+CONF_WATER_SETPOINT_COOL_ENTITY = "water_setpoint_cool_entity"  # Dynamic water setpoint entity for cooling
+CONF_WATER_TOLERANCE = "water_tolerance"  # Optional tolerance for water temperature guard
 CONF_MIN_TEMP = "min_temp"
 CONF_MAX_TEMP = "max_temp"
 CONF_TARGET_TEMP_HIGH = "target_temp_high"
@@ -166,6 +172,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             [PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
         ),
         vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_WATER_SENSOR): cv.entity_id,
+        vol.Optional(CONF_WATER_SETPOINT_HEAT): vol.Coerce(float),
+        vol.Optional(CONF_WATER_SETPOINT_COOL): vol.Coerce(float),
+        vol.Optional(CONF_WATER_SETPOINT_HEAT_ENTITY): cv.entity_id,
+        vol.Optional(CONF_WATER_SETPOINT_COOL_ENTITY): cv.entity_id,
+        vol.Optional(CONF_WATER_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
     }
 )
 
@@ -204,6 +216,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     unique_id = config.get(CONF_UNIQUE_ID)
     humidity_sensor_entity_id = config.get(CONF_HUMIDITY_SENSOR)
     consent_entity_id = config.get(CONF_CONSENT_ENTITY)
+    water_sensor_entity_id = config.get(CONF_WATER_SENSOR)
+    water_setpoint_heat = config.get(CONF_WATER_SETPOINT_HEAT)
+    water_setpoint_cool = config.get(CONF_WATER_SETPOINT_COOL)
+    water_setpoint_heat_entity_id = config.get(CONF_WATER_SETPOINT_HEAT_ENTITY)
+    water_setpoint_cool_entity_id = config.get(CONF_WATER_SETPOINT_COOL_ENTITY)
+    water_tolerance = config.get(CONF_WATER_TOLERANCE)
 
     async_add_entities(
         [
@@ -237,6 +255,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 unique_id,
                 humidity_sensor_entity_id,
                 consent_entity_id,
+                water_sensor_entity_id,
+                water_setpoint_heat,
+                water_setpoint_cool,
+                water_setpoint_heat_entity_id,
+                water_setpoint_cool_entity_id,
+                water_tolerance,
             )
         ]
     )
@@ -276,6 +300,12 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
             unique_id,
             humidity_sensor_entity_id,
             consent_entity_id,
+            water_sensor_entity_id=None,
+            water_setpoint_heat=None,
+            water_setpoint_cool=None,
+            water_setpoint_heat_entity_id=None,
+            water_setpoint_cool_entity_id=None,
+            water_tolerance=DEFAULT_TOLERANCE,
     ):
         """Initialize the thermostat."""
         self._name = name
@@ -290,6 +320,23 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
         self.consent_entity_id = consent_entity_id
         # When no consent entity is configured, consent is always granted
         self._consent_granted = consent_entity_id is None
+
+        # Water temperature guard
+        # water_sensor: optional sensor that reads the water supply temperature
+        # water_setpoint_heat / water_setpoint_heat_entity: threshold for heating mode
+        #   heating allowed when water_temp >= setpoint_heat (water is hot enough)
+        # water_setpoint_cool / water_setpoint_cool_entity: threshold for cooling mode
+        #   cooling allowed when water_temp <= setpoint_cool (water is cold enough)
+        # If no water sensor is configured, the guard is always satisfied.
+        self.water_sensor_entity_id = water_sensor_entity_id
+        self.water_setpoint_heat_entity_id = water_setpoint_heat_entity_id
+        self.water_setpoint_cool_entity_id = water_setpoint_cool_entity_id
+        self._water_setpoint_heat_fixed = water_setpoint_heat    # fixed YAML value for heating (e.g. 30)
+        self._water_setpoint_cool_fixed = water_setpoint_cool    # fixed YAML value for cooling (e.g. 15)
+        self._water_setpoint_heat_entity_value = None            # live value from heating setpoint entity
+        self._water_setpoint_cool_entity_value = None            # live value from cooling setpoint entity
+        self._water_tolerance = water_tolerance
+        self._cur_water_temp = None                              # current water temperature
 
         # Tell Home Assistant that this integration is migrated
         self._enable_turn_on_off_backwards_compatibility = False
@@ -390,6 +437,11 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
         self.register_event_listener(self.dryer_entity_id, self._async_switch_changed)
         self.register_event_listener(self.consent_entity_id, self._async_consent_entity_changed)
 
+        # Water temperature guard listeners
+        self.register_event_listener(self.water_sensor_entity_id, self._async_water_sensor_changed)
+        self.register_event_listener(self.water_setpoint_heat_entity_id, self._async_water_setpoint_entity_changed)
+        self.register_event_listener(self.water_setpoint_cool_entity_id, self._async_water_setpoint_entity_changed)
+
         if self.consent_entity_id:
             consent_state = self.hass.states.get(self.consent_entity_id)
             self._consent_granted = self._extract_consent_from_state(consent_state)
@@ -487,6 +539,30 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
                 ):
                     self._async_update_humidity(humidity_sensor_state)
 
+            if self.water_sensor_entity_id:
+                water_sensor_state = self.hass.states.get(self.water_sensor_entity_id)
+                if water_sensor_state and water_sensor_state.state not in (
+                        STATE_UNAVAILABLE,
+                        STATE_UNKNOWN,
+                ):
+                    self._async_update_water_temp(water_sensor_state)
+
+            if self.water_setpoint_heat_entity_id:
+                water_sp_heat_state = self.hass.states.get(self.water_setpoint_heat_entity_id)
+                if water_sp_heat_state and water_sp_heat_state.state not in (
+                        STATE_UNAVAILABLE,
+                        STATE_UNKNOWN,
+                ):
+                    self._async_update_water_setpoint_heat(water_sp_heat_state)
+
+            if self.water_setpoint_cool_entity_id:
+                water_sp_cool_state = self.hass.states.get(self.water_setpoint_cool_entity_id)
+                if water_sp_cool_state and water_sp_cool_state.state not in (
+                        STATE_UNAVAILABLE,
+                        STATE_UNKNOWN,
+                ):
+                    self._async_update_water_setpoint_cool(water_sp_cool_state)
+
         if self.hass.state == CoreState.running:
             _async_startup()
         else:
@@ -551,6 +627,8 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
         if self._hvac_mode == HVAC_MODE_OFF:
             return CURRENT_HVAC_OFF
         if not self._consent_granted:
+            return CURRENT_HVAC_IDLE
+        if self._is_water_guard_blocked:
             return CURRENT_HVAC_IDLE
         if not self._is_device_active:
             return CURRENT_HVAC_IDLE
@@ -844,6 +922,111 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
                 await self._async_control_heating(force=True)
         self.async_write_ha_state()
 
+    # ---------------------------------------------------------------------------
+    # Water temperature guard — callbacks, helpers and property
+    # ---------------------------------------------------------------------------
+
+    @callback
+    async def _async_water_sensor_changed(self, event: Event[EventStateChangedData]):
+        """Handle water supply temperature sensor changes."""
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return
+        self._async_update_water_temp(new_state)
+        await self._async_control_heating()
+        self.async_write_ha_state()
+
+    @callback
+    async def _async_water_setpoint_entity_changed(self, event: Event[EventStateChangedData]):
+        """Handle dynamic water setpoint entity changes (heat or cool)."""
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return
+        entity_id = event.data.get("entity_id")
+        if entity_id == self.water_setpoint_heat_entity_id:
+            self._async_update_water_setpoint_heat(new_state)
+        elif entity_id == self.water_setpoint_cool_entity_id:
+            self._async_update_water_setpoint_cool(new_state)
+        await self._async_control_heating()
+        self.async_write_ha_state()
+
+    @callback
+    def _async_update_water_temp(self, state):
+        """Update cached water temperature from sensor state."""
+        try:
+            self._cur_water_temp = float(state.state)
+        except ValueError as ex:
+            _LOGGER.error("Unable to update water temperature from sensor: %s", ex)
+
+    @callback
+    def _async_update_water_setpoint_heat(self, state):
+        """Update cached heating water setpoint from entity state."""
+        try:
+            self._water_setpoint_heat_entity_value = float(state.state)
+        except ValueError as ex:
+            _LOGGER.error("Unable to update water heating setpoint from entity: %s", ex)
+
+    @callback
+    def _async_update_water_setpoint_cool(self, state):
+        """Update cached cooling water setpoint from entity state."""
+        try:
+            self._water_setpoint_cool_entity_value = float(state.state)
+        except ValueError as ex:
+            _LOGGER.error("Unable to update water cooling setpoint from entity: %s", ex)
+
+    @property
+    def _effective_water_setpoint_heat(self):
+        """Return the active water setpoint for heating.
+
+        Entity value takes priority over fixed YAML value.
+        Returns None if neither is configured.
+        """
+        if self._water_setpoint_heat_entity_value is not None:
+            return self._water_setpoint_heat_entity_value
+        return self._water_setpoint_heat_fixed
+
+    @property
+    def _effective_water_setpoint_cool(self):
+        """Return the active water setpoint for cooling.
+
+        Entity value takes priority over fixed YAML value.
+        Returns None if neither is configured.
+        """
+        if self._water_setpoint_cool_entity_value is not None:
+            return self._water_setpoint_cool_entity_value
+        return self._water_setpoint_cool_fixed
+
+    def _is_water_guard_satisfied_for_heat(self):
+        """Return True if water is hot enough to allow heating.
+
+        Condition: cur_water_temp >= setpoint_heat - tolerance
+        """
+        if self.water_sensor_entity_id is None:
+            return True
+        setpoint = self._effective_water_setpoint_heat
+        if setpoint is None or self._cur_water_temp is None:
+            # Guard not fully configured or sensor unavailable — allow operation
+            return True
+        return self._cur_water_temp >= setpoint - self._water_tolerance
+
+    def _is_water_guard_satisfied_for_cool(self):
+        """Return True if water is cold enough to allow cooling.
+
+        Condition: cur_water_temp <= setpoint_cool + tolerance
+        """
+        if self.water_sensor_entity_id is None:
+            return True
+        setpoint = self._effective_water_setpoint_cool
+        if setpoint is None or self._cur_water_temp is None:
+            return True
+        return self._cur_water_temp <= setpoint + self._water_tolerance
+
+    def _is_water_guard_satisfied(self, for_heat: bool) -> bool:
+        """Return True if the water guard allows the requested operation."""
+        if for_heat:
+            return self._is_water_guard_satisfied_for_heat()
+        return self._is_water_guard_satisfied_for_cool()
+
     async def _async_control_heating(self, time=None, force=False, previous_mode: HVACMode=None):
         """Check if we need to turn heating on or off."""
         async with self._temp_lock:
@@ -866,6 +1049,38 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
                 if self._is_device_active:
                     await self._async_turn_off_all_devices()
                 return
+
+            # Water temperature guard check
+            # In HEAT_COOL mode the guard is evaluated per-device in the main logic below.
+            # In single-mode (HEAT / COOL / FAN / DRY) we check here and block entirely if unsatisfied.
+            if self.water_sensor_entity_id and self._hvac_mode not in (HVAC_MODE_HEAT_COOL, HVAC_MODE_OFF):
+                # Determine whether the current mode acts as heating or cooling for guard purposes
+                is_heat_action = (
+                    self._hvac_mode == HVAC_MODE_HEAT or
+                    (self._hvac_mode == HVAC_MODE_FAN_ONLY and self.fan_behavior == FAN_MODE_HEAT) or
+                    (self._hvac_mode == HVAC_MODE_DRY and self.dryer_behavior == DRYER_MODE_HEAT)
+                )
+                is_cool_action = (
+                    self._hvac_mode == HVAC_MODE_COOL or
+                    (self._hvac_mode == HVAC_MODE_FAN_ONLY and self.fan_behavior == FAN_MODE_COOL) or
+                    (self._hvac_mode == HVAC_MODE_DRY and self.dryer_behavior == DRYER_MODE_COOL)
+                )
+                if is_heat_action and not self._is_water_guard_satisfied(for_heat=True):
+                    _LOGGER.debug(
+                        "Water guard blocks heating: water_temp=%s, setpoint_heat=%s",
+                        self._cur_water_temp, self._effective_water_setpoint_heat
+                    )
+                    if self._is_device_active:
+                        await self._async_turn_off_all_devices()
+                    return
+                if is_cool_action and not self._is_water_guard_satisfied(for_heat=False):
+                    _LOGGER.debug(
+                        "Water guard blocks cooling: water_temp=%s, setpoint_cool=%s",
+                        self._cur_water_temp, self._effective_water_setpoint_cool
+                    )
+                    if self._is_device_active:
+                        await self._async_turn_off_all_devices()
+                    return
 
             # This check sets the active entity outside of the checks below to make it available for keep-alive logic
             def determine_active_entity():
@@ -937,7 +1152,11 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
                         self.heater_entity_id,
                     )
                     await self._async_cooler_turn_off()
-                    await self._async_heater_turn_on()
+                    if self._is_water_guard_satisfied(for_heat=True):
+                        await self._async_heater_turn_on()
+                    else:
+                        _LOGGER.debug("Water guard blocks heater in HEAT_COOL: water_temp=%s", self._cur_water_temp)
+                        await self._async_heater_turn_off()
                 elif too_hot_overshot:
                     _LOGGER.info(
                         "Overshot upper bound! Turning on cooler %s and turning off heater %s",
@@ -945,7 +1164,11 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
                         self.heater_entity_id,
                     )
                     await self._async_heater_turn_off()
-                    await self._async_cooler_turn_on()
+                    if self._is_water_guard_satisfied(for_heat=False):
+                        await self._async_cooler_turn_on()
+                    else:
+                        _LOGGER.debug("Water guard blocks cooler in HEAT_COOL: water_temp=%s", self._cur_water_temp)
+                        await self._async_cooler_turn_off()
                 elif time is not None:
                     _LOGGER.info("Keep-alive - Turning on %s", active_entity)
                     if self.hass.states.is_state(self.heater_entity_id, STATE_ON):
@@ -996,11 +1219,17 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
                 too_cold = self._is_too_cold_activate()
                 too_hot = self._is_too_hot_activate()
                 if too_hot and self._hvac_mode in [HVAC_MODE_COOL, HVAC_MODE_HEAT_COOL]:
-                    _LOGGER.info("Turning on cooler %s", self.cooler_entity_id)
-                    await self._async_cooler_turn_on()
+                    if self._is_water_guard_satisfied(for_heat=False):
+                        _LOGGER.info("Turning on cooler %s", self.cooler_entity_id)
+                        await self._async_cooler_turn_on()
+                    else:
+                        _LOGGER.debug("Water guard blocks cooler activation: water_temp=%s", self._cur_water_temp)
                 elif too_cold and self._hvac_mode in [HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL]:
-                    _LOGGER.info("Turning on heater %s", self.heater_entity_id)
-                    await self._async_heater_turn_on()
+                    if self._is_water_guard_satisfied(for_heat=True):
+                        _LOGGER.info("Turning on heater %s", self.heater_entity_id)
+                        await self._async_heater_turn_on()
+                    else:
+                        _LOGGER.debug("Water guard blocks heater activation: water_temp=%s", self._cur_water_temp)
                 elif self._hvac_mode == HVAC_MODE_FAN_ONLY:
                     if (
                         (too_hot and self.fan_behavior == FAN_MODE_COOL)
@@ -1047,6 +1276,50 @@ class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
                   ([self.dryer_entity_id] if self.dryer_entity_id else [])
         device_states = [self.hass.states.is_state(dev, STATE_ON) for dev in devices]
         return next((state for state in device_states if state), False)
+
+    @property
+    def _is_water_guard_blocked(self):
+        """Return True if the water guard is currently blocking operation.
+
+        This is a summary view for hvac_action and extra_state_attributes.
+        In HEAT_COOL mode the guard may block one device but not the other,
+        so we return True only when both relevant checks fail.
+        """
+        if self.water_sensor_entity_id is None:
+            return False
+        if self._hvac_mode == HVAC_MODE_HEAT:
+            return not self._is_water_guard_satisfied(for_heat=True)
+        if self._hvac_mode == HVAC_MODE_COOL:
+            return not self._is_water_guard_satisfied(for_heat=False)
+        if self._hvac_mode in (HVAC_MODE_FAN_ONLY, HVAC_MODE_DRY):
+            is_heat_action = (
+                (self._hvac_mode == HVAC_MODE_FAN_ONLY and self.fan_behavior == FAN_MODE_HEAT) or
+                (self._hvac_mode == HVAC_MODE_DRY and self.dryer_behavior == DRYER_MODE_HEAT)
+            )
+            if is_heat_action:
+                return not self._is_water_guard_satisfied(for_heat=True)
+            is_cool_action = (
+                (self._hvac_mode == HVAC_MODE_FAN_ONLY and self.fan_behavior == FAN_MODE_COOL) or
+                (self._hvac_mode == HVAC_MODE_DRY and self.dryer_behavior == DRYER_MODE_COOL)
+            )
+            if is_cool_action:
+                return not self._is_water_guard_satisfied(for_heat=False)
+        # HEAT_COOL: blocked only if both heater and cooler are blocked
+        if self._hvac_mode == HVAC_MODE_HEAT_COOL:
+            return (not self._is_water_guard_satisfied(for_heat=True) and
+                    not self._is_water_guard_satisfied(for_heat=False))
+        return False
+
+    @property
+    def extra_state_attributes(self):
+        """Return additional state attributes for the water temperature guard."""
+        attrs = {}
+        if self.water_sensor_entity_id:
+            attrs["water_temperature"] = self._cur_water_temp
+            attrs["water_setpoint_heat"] = self._effective_water_setpoint_heat
+            attrs["water_setpoint_cool"] = self._effective_water_setpoint_cool
+            attrs["water_guard_active"] = self._is_water_guard_blocked
+        return attrs
 
     @property
     def supported_features(self):

--- a/custom_components/dualmode_generic/climate.py
+++ b/custom_components/dualmode_generic/climate.py
@@ -266,6 +266,82 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the dual mode generic thermostat from a config entry (UI-based)."""
+    # Merge data and options — options take priority for fields that can be changed
+    config = {**config_entry.data, **config_entry.options}
+
+    unit = hass.config.units.temperature_unit
+
+    # Parse duration fields from dict format (DurationSelector returns {"hours":0,"minutes":5,"seconds":0})
+    def parse_duration(value):
+        """Convert duration dict or timedelta to timedelta, or None."""
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            import datetime
+            return datetime.timedelta(
+                hours=value.get("hours", 0),
+                minutes=value.get("minutes", 0),
+                seconds=value.get("seconds", 0),
+            )
+        return value
+
+    # Parse precision from string to float
+    def parse_precision(value):
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None
+
+    min_cycle_duration = parse_duration(config.get("min_cycle_duration"))
+    keep_alive = parse_duration(config.get("keep_alive"))
+
+    async_add_entities(
+        [
+            DualModeGenericThermostat(
+                config.get("name", "Generic Thermostat"),
+                config.get("heater"),
+                config.get("cooler"),
+                config.get("target_sensor"),
+                config.get("fan"),
+                config.get("fan_behavior", "neutral"),
+                config.get("dryer"),
+                config.get("dryer_behavior", "neutral"),
+                config.get("reverse_cycle", []),
+                config.get("min_temp"),
+                config.get("max_temp"),
+                config.get("target_temp"),
+                config.get("target_temp_high"),
+                config.get("target_temp_low"),
+                min_cycle_duration,
+                config.get("cold_tolerance", 0.3),
+                config.get("hot_tolerance", 0.3),
+                keep_alive,
+                config.get("initial_hvac_mode"),
+                config.get("away_temp"),
+                config.get("away_temp_heater"),
+                config.get("away_temp_cooler"),
+                parse_precision(config.get("precision")),
+                parse_precision(config.get("target_temp_step")),
+                config.get("enable_heat_cool", False),
+                unit,
+                config.get("unique_id"),
+                config.get("target_humidity_sensor"),
+                config.get("consent_entity"),
+                config.get("water_sensor"),
+                config.get("water_setpoint_heat"),
+                config.get("water_setpoint_cool"),
+                config.get("water_setpoint_heat_entity"),
+                config.get("water_setpoint_cool_entity"),
+                config.get("water_tolerance", 0.3),
+            )
+        ]
+    )
+
+
 class DualModeGenericThermostat(ClimateEntity, RestoreEntity):
     """Representation of a Generic Thermostat device."""
 

--- a/custom_components/dualmode_generic/config_flow.py
+++ b/custom_components/dualmode_generic/config_flow.py
@@ -1,0 +1,339 @@
+"""Config flow and Options flow for Multi-Mode Generic Thermostat."""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.helpers import selector
+
+from . import DOMAIN
+
+# ---------------------------------------------------------------------------
+# Selector helpers — reusable selectors for entity pickers
+# ---------------------------------------------------------------------------
+
+ENTITY_SELECTOR = selector.EntitySelector(
+    selector.EntitySelectorConfig(domain=["switch", "input_boolean"])
+)
+SENSOR_SELECTOR = selector.EntitySelector(
+    selector.EntitySelectorConfig(domain=["sensor"])
+)
+CONSENT_ENTITY_SELECTOR = selector.EntitySelector(
+    selector.EntitySelectorConfig(domain=["binary_sensor", "input_boolean", "calendar", "switch"])
+)
+NUMBER_ENTITY_SELECTOR = selector.EntitySelector(
+    selector.EntitySelectorConfig(domain=["input_number", "number", "sensor"])
+)
+DURATION_SELECTOR = selector.DurationSelector(
+    selector.DurationSelectorConfig(enable_day=False)
+)
+TEMPERATURE_SELECTOR = selector.NumberSelector(
+    selector.NumberSelectorConfig(mode=selector.NumberSelectorMode.BOX, step=0.1)
+)
+TOLERANCE_SELECTOR = selector.NumberSelector(
+    selector.NumberSelectorConfig(min=0.0, max=10.0, step=0.1, mode=selector.NumberSelectorMode.BOX)
+)
+PRECISION_SELECTOR = selector.SelectSelector(
+    selector.SelectSelectorConfig(
+        options=[
+            selector.SelectOptionDict(value="0.1", label="0.1"),
+            selector.SelectOptionDict(value="0.5", label="0.5"),
+            selector.SelectOptionDict(value="1.0", label="1.0"),
+        ],
+        mode=selector.SelectSelectorMode.DROPDOWN,
+    )
+)
+FAN_BEHAVIOR_SELECTOR = selector.SelectSelector(
+    selector.SelectSelectorConfig(
+        options=[
+            selector.SelectOptionDict(value="cooler", label="Cooler"),
+            selector.SelectOptionDict(value="heater", label="Heater"),
+            selector.SelectOptionDict(value="neutral", label="Neutral"),
+        ],
+        mode=selector.SelectSelectorMode.DROPDOWN,
+    )
+)
+DRYER_BEHAVIOR_SELECTOR = selector.SelectSelector(
+    selector.SelectSelectorConfig(
+        options=[
+            selector.SelectOptionDict(value="cooler", label="Cooler"),
+            selector.SelectOptionDict(value="heater", label="Heater"),
+            selector.SelectOptionDict(value="neutral", label="Neutral"),
+        ],
+        mode=selector.SelectSelectorMode.DROPDOWN,
+    )
+)
+REVERSE_CYCLE_SELECTOR = selector.SelectSelector(
+    selector.SelectSelectorConfig(
+        options=[
+            selector.SelectOptionDict(value="heater", label="Heater"),
+            selector.SelectOptionDict(value="cooler", label="Cooler"),
+            selector.SelectOptionDict(value="fan", label="Fan"),
+            selector.SelectOptionDict(value="dryer", label="Dryer"),
+        ],
+        mode=selector.SelectSelectorMode.DROPDOWN,
+        multiple=True,
+    )
+)
+INITIAL_HVAC_MODE_SELECTOR = selector.SelectSelector(
+    selector.SelectSelectorConfig(
+        options=[
+            selector.SelectOptionDict(value="off", label="Off"),
+            selector.SelectOptionDict(value="heat", label="Heat"),
+            selector.SelectOptionDict(value="cool", label="Cool"),
+            selector.SelectOptionDict(value="heat_cool", label="Heat/Cool"),
+            selector.SelectOptionDict(value="fan_only", label="Fan Only"),
+            selector.SelectOptionDict(value="dry", label="Dry"),
+        ],
+        mode=selector.SelectSelectorMode.DROPDOWN,
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Config Flow — multi-step initial setup
+# ---------------------------------------------------------------------------
+
+
+class DualModeGenericConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Multi-Mode Generic Thermostat."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._data: dict[str, Any] = {}
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        """Get the options flow handler."""
+        return DualModeGenericOptionsFlow(config_entry)
+
+    # ---- Step 1: Base ----
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        """Step 1 — Base configuration: name, temperature sensor, humidity sensor."""
+        errors = {}
+        if user_input is not None:
+            self._data.update(user_input)
+            return await self.async_step_devices()
+
+        schema = vol.Schema(
+            {
+                vol.Required("name", default="Generic Thermostat"): selector.TextSelector(),
+                vol.Required("target_sensor"): SENSOR_SELECTOR,
+                vol.Optional("target_humidity_sensor"): SENSOR_SELECTOR,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    # ---- Step 2: Devices ----
+    async def async_step_devices(self, user_input: dict[str, Any] | None = None):
+        """Step 2 — Devices: heater, cooler, fan, dryer, behaviors, reverse cycle."""
+        errors = {}
+        if user_input is not None:
+            self._data.update(user_input)
+            return await self.async_step_temperature()
+
+        schema = vol.Schema(
+            {
+                vol.Optional("heater"): ENTITY_SELECTOR,
+                vol.Optional("cooler"): ENTITY_SELECTOR,
+                vol.Optional("fan"): ENTITY_SELECTOR,
+                vol.Optional("fan_behavior", default="neutral"): FAN_BEHAVIOR_SELECTOR,
+                vol.Optional("dryer"): ENTITY_SELECTOR,
+                vol.Optional("dryer_behavior", default="neutral"): DRYER_BEHAVIOR_SELECTOR,
+                vol.Optional("reverse_cycle", default=[]): REVERSE_CYCLE_SELECTOR,
+                vol.Optional("enable_heat_cool", default=False): selector.BooleanSelector(),
+            }
+        )
+        return self.async_show_form(step_id="devices", data_schema=schema, errors=errors)
+
+    # ---- Step 3: Temperature & Control ----
+    async def async_step_temperature(self, user_input: dict[str, Any] | None = None):
+        """Step 3 — Temperature parameters: targets, tolerances, precision."""
+        errors = {}
+        if user_input is not None:
+            self._data.update(user_input)
+            return await self.async_step_timing()
+
+        schema = vol.Schema(
+            {
+                vol.Optional("target_temp"): TEMPERATURE_SELECTOR,
+                vol.Optional("target_temp_high"): TEMPERATURE_SELECTOR,
+                vol.Optional("target_temp_low"): TEMPERATURE_SELECTOR,
+                vol.Optional("min_temp"): TEMPERATURE_SELECTOR,
+                vol.Optional("max_temp"): TEMPERATURE_SELECTOR,
+                vol.Optional("cold_tolerance", default=0.3): TOLERANCE_SELECTOR,
+                vol.Optional("hot_tolerance", default=0.3): TOLERANCE_SELECTOR,
+                vol.Optional("precision"): PRECISION_SELECTOR,
+                vol.Optional("target_temp_step"): PRECISION_SELECTOR,
+            }
+        )
+        return self.async_show_form(step_id="temperature", data_schema=schema, errors=errors)
+
+    # ---- Step 4: Timing & Modes ----
+    async def async_step_timing(self, user_input: dict[str, Any] | None = None):
+        """Step 4 — Timing and modes: cycle duration, keep-alive, initial mode, away temps."""
+        errors = {}
+        if user_input is not None:
+            self._data.update(user_input)
+            return await self.async_step_water_guard()
+
+        schema = vol.Schema(
+            {
+                vol.Optional("min_cycle_duration"): DURATION_SELECTOR,
+                vol.Optional("keep_alive"): DURATION_SELECTOR,
+                vol.Optional("initial_hvac_mode", default="off"): INITIAL_HVAC_MODE_SELECTOR,
+                vol.Optional("away_temp"): TEMPERATURE_SELECTOR,
+                vol.Optional("away_temp_heater"): TEMPERATURE_SELECTOR,
+                vol.Optional("away_temp_cooler"): TEMPERATURE_SELECTOR,
+                vol.Optional("consent_entity"): CONSENT_ENTITY_SELECTOR,
+            }
+        )
+        return self.async_show_form(step_id="timing", data_schema=schema, errors=errors)
+
+    # ---- Step 5: Water Guard ----
+    async def async_step_water_guard(self, user_input: dict[str, Any] | None = None):
+        """Step 5 — Water temperature guard: sensor, setpoints, tolerance."""
+        errors = {}
+        if user_input is not None:
+            self._data.update(user_input)
+            return self._create_entry()
+
+        schema = vol.Schema(
+            {
+                vol.Optional("water_sensor"): SENSOR_SELECTOR,
+                vol.Optional("water_setpoint_heat"): TEMPERATURE_SELECTOR,
+                vol.Optional("water_setpoint_cool"): TEMPERATURE_SELECTOR,
+                vol.Optional("water_setpoint_heat_entity"): NUMBER_ENTITY_SELECTOR,
+                vol.Optional("water_setpoint_cool_entity"): NUMBER_ENTITY_SELECTOR,
+                vol.Optional("water_tolerance", default=0.3): TOLERANCE_SELECTOR,
+            }
+        )
+        return self.async_show_form(step_id="water_guard", data_schema=schema, errors=errors)
+
+    # ---- Create entry ----
+    def _create_entry(self):
+        """Create the config entry with all collected data."""
+        # Auto-generate unique_id
+        self._data["unique_id"] = str(uuid.uuid4())
+        title = self._data.get("name", "Generic Thermostat")
+        return self.async_create_entry(title=title, data=self._data)
+
+
+# ---------------------------------------------------------------------------
+# Options Flow — menu-based editing by category
+# ---------------------------------------------------------------------------
+
+
+class DualModeGenericOptionsFlow(config_entries.OptionsFlow):
+    """Handle options for Multi-Mode Generic Thermostat."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self._config_entry = config_entry
+
+    def _get(self, key: str, default=None):
+        """Get current value from options (if previously changed) or data (initial config)."""
+        return self._config_entry.options.get(
+            key, self._config_entry.data.get(key, default)
+        )
+
+    # ---- Menu ----
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        """Show the options menu."""
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=["devices", "temperature", "timing", "water_guard"],
+        )
+
+    # ---- Devices ----
+    async def async_step_devices(self, user_input: dict[str, Any] | None = None):
+        """Edit device entities and behaviors."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="", data={**self._config_entry.options, **user_input}
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Optional("heater", description={"suggested_value": self._get("heater", "")}): ENTITY_SELECTOR,
+                vol.Optional("cooler", description={"suggested_value": self._get("cooler", "")}): ENTITY_SELECTOR,
+                vol.Optional("fan", description={"suggested_value": self._get("fan", "")}): ENTITY_SELECTOR,
+                vol.Optional("fan_behavior", default=self._get("fan_behavior", "neutral")): FAN_BEHAVIOR_SELECTOR,
+                vol.Optional("dryer", description={"suggested_value": self._get("dryer", "")}): ENTITY_SELECTOR,
+                vol.Optional("dryer_behavior", default=self._get("dryer_behavior", "neutral")): DRYER_BEHAVIOR_SELECTOR,
+                vol.Optional("reverse_cycle", default=self._get("reverse_cycle", [])): REVERSE_CYCLE_SELECTOR,
+                vol.Optional("enable_heat_cool", default=self._get("enable_heat_cool", False)): selector.BooleanSelector(),
+            }
+        )
+        return self.async_show_form(step_id="devices", data_schema=schema)
+
+    # ---- Temperature ----
+    async def async_step_temperature(self, user_input: dict[str, Any] | None = None):
+        """Edit temperature parameters."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="", data={**self._config_entry.options, **user_input}
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Optional("target_temp", description={"suggested_value": self._get("target_temp")}): TEMPERATURE_SELECTOR,
+                vol.Optional("target_temp_high", description={"suggested_value": self._get("target_temp_high")}): TEMPERATURE_SELECTOR,
+                vol.Optional("target_temp_low", description={"suggested_value": self._get("target_temp_low")}): TEMPERATURE_SELECTOR,
+                vol.Optional("min_temp", description={"suggested_value": self._get("min_temp")}): TEMPERATURE_SELECTOR,
+                vol.Optional("max_temp", description={"suggested_value": self._get("max_temp")}): TEMPERATURE_SELECTOR,
+                vol.Optional("cold_tolerance", default=self._get("cold_tolerance", 0.3)): TOLERANCE_SELECTOR,
+                vol.Optional("hot_tolerance", default=self._get("hot_tolerance", 0.3)): TOLERANCE_SELECTOR,
+                vol.Optional("precision", description={"suggested_value": self._get("precision")}): PRECISION_SELECTOR,
+                vol.Optional("target_temp_step", description={"suggested_value": self._get("target_temp_step")}): PRECISION_SELECTOR,
+            }
+        )
+        return self.async_show_form(step_id="temperature", data_schema=schema)
+
+    # ---- Timing & Modes ----
+    async def async_step_timing(self, user_input: dict[str, Any] | None = None):
+        """Edit timing and mode options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="", data={**self._config_entry.options, **user_input}
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Optional("min_cycle_duration", description={"suggested_value": self._get("min_cycle_duration")}): DURATION_SELECTOR,
+                vol.Optional("keep_alive", description={"suggested_value": self._get("keep_alive")}): DURATION_SELECTOR,
+                vol.Optional("initial_hvac_mode", default=self._get("initial_hvac_mode", "off")): INITIAL_HVAC_MODE_SELECTOR,
+                vol.Optional("away_temp", description={"suggested_value": self._get("away_temp")}): TEMPERATURE_SELECTOR,
+                vol.Optional("away_temp_heater", description={"suggested_value": self._get("away_temp_heater")}): TEMPERATURE_SELECTOR,
+                vol.Optional("away_temp_cooler", description={"suggested_value": self._get("away_temp_cooler")}): TEMPERATURE_SELECTOR,
+                vol.Optional("consent_entity", description={"suggested_value": self._get("consent_entity", "")}): CONSENT_ENTITY_SELECTOR,
+            }
+        )
+        return self.async_show_form(step_id="timing", data_schema=schema)
+
+    # ---- Water Guard ----
+    async def async_step_water_guard(self, user_input: dict[str, Any] | None = None):
+        """Edit water temperature guard options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="", data={**self._config_entry.options, **user_input}
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Optional("water_sensor", description={"suggested_value": self._get("water_sensor", "")}): SENSOR_SELECTOR,
+                vol.Optional("water_setpoint_heat", description={"suggested_value": self._get("water_setpoint_heat")}): TEMPERATURE_SELECTOR,
+                vol.Optional("water_setpoint_cool", description={"suggested_value": self._get("water_setpoint_cool")}): TEMPERATURE_SELECTOR,
+                vol.Optional("water_setpoint_heat_entity", description={"suggested_value": self._get("water_setpoint_heat_entity", "")}): NUMBER_ENTITY_SELECTOR,
+                vol.Optional("water_setpoint_cool_entity", description={"suggested_value": self._get("water_setpoint_cool_entity", "")}): NUMBER_ENTITY_SELECTOR,
+                vol.Optional("water_tolerance", default=self._get("water_tolerance", 0.3)): TOLERANCE_SELECTOR,
+            }
+        )
+        return self.async_show_form(step_id="water_guard", data_schema=schema)

--- a/custom_components/dualmode_generic/manifest.json
+++ b/custom_components/dualmode_generic/manifest.json
@@ -3,7 +3,8 @@
     "name": "Multi-Mode Generic Thermostat",
     "documentation": "https://github.com/zacs/ha-dualmodegeneric",
     "issue_tracker": "https://github.com/zacs/ha-dualmodegeneric/issues",
-    "version": "0.2.1",
+    "version": "0.3.0",
+    "config_flow": true,
     "dependencies": [],
     "codeowners": ["@zacs"],
     "requirements": []

--- a/custom_components/dualmode_generic/strings.json
+++ b/custom_components/dualmode_generic/strings.json
@@ -1,0 +1,137 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Base Configuration",
+                "description": "Configure the basic settings for the thermostat.",
+                "data": {
+                    "name": "Name",
+                    "target_sensor": "Temperature sensor",
+                    "target_humidity_sensor": "Humidity sensor (optional)"
+                }
+            },
+            "devices": {
+                "title": "Devices",
+                "description": "Configure the heating, cooling, fan, and dryer devices.",
+                "data": {
+                    "heater": "Heater switch",
+                    "cooler": "Cooler switch",
+                    "fan": "Fan switch",
+                    "fan_behavior": "Fan behavior",
+                    "dryer": "Dryer switch",
+                    "dryer_behavior": "Dryer behavior",
+                    "reverse_cycle": "Reverse cycle devices",
+                    "enable_heat_cool": "Enable Heat/Cool mode"
+                }
+            },
+            "temperature": {
+                "title": "Temperature & Control",
+                "description": "Configure temperature targets, limits, and tolerances.",
+                "data": {
+                    "target_temp": "Default target temperature",
+                    "target_temp_high": "Default upper target (Heat/Cool mode)",
+                    "target_temp_low": "Default lower target (Heat/Cool mode)",
+                    "min_temp": "Minimum temperature",
+                    "max_temp": "Maximum temperature",
+                    "cold_tolerance": "Cold tolerance",
+                    "hot_tolerance": "Hot tolerance",
+                    "precision": "Precision",
+                    "target_temp_step": "Temperature step"
+                }
+            },
+            "timing": {
+                "title": "Timing & Modes",
+                "description": "Configure cycle timing, keep-alive, initial mode, and away temperatures.",
+                "data": {
+                    "min_cycle_duration": "Minimum cycle duration",
+                    "keep_alive": "Keep-alive interval",
+                    "initial_hvac_mode": "Initial HVAC mode",
+                    "away_temp": "Away temperature",
+                    "away_temp_heater": "Away temperature (heater)",
+                    "away_temp_cooler": "Away temperature (cooler)",
+                    "consent_entity": "Consent entity"
+                }
+            },
+            "water_guard": {
+                "title": "Water Temperature Guard",
+                "description": "Configure water supply temperature guard to prevent operation when water is not at the required temperature.",
+                "data": {
+                    "water_sensor": "Water temperature sensor",
+                    "water_setpoint_heat": "Water setpoint for heating (min water temp to allow heating)",
+                    "water_setpoint_cool": "Water setpoint for cooling (max water temp to allow cooling)",
+                    "water_setpoint_heat_entity": "Water setpoint heat entity (overrides fixed value)",
+                    "water_setpoint_cool_entity": "Water setpoint cool entity (overrides fixed value)",
+                    "water_tolerance": "Water temperature tolerance"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Options",
+                "description": "Select a category to edit.",
+                "menu_options": {
+                    "devices": "Devices",
+                    "temperature": "Temperature & Control",
+                    "timing": "Timing & Modes",
+                    "water_guard": "Water Temperature Guard"
+                }
+            },
+            "devices": {
+                "title": "Devices",
+                "description": "Edit heating, cooling, fan, and dryer devices.",
+                "data": {
+                    "heater": "Heater switch",
+                    "cooler": "Cooler switch",
+                    "fan": "Fan switch",
+                    "fan_behavior": "Fan behavior",
+                    "dryer": "Dryer switch",
+                    "dryer_behavior": "Dryer behavior",
+                    "reverse_cycle": "Reverse cycle devices",
+                    "enable_heat_cool": "Enable Heat/Cool mode"
+                }
+            },
+            "temperature": {
+                "title": "Temperature & Control",
+                "description": "Edit temperature targets, limits, and tolerances.",
+                "data": {
+                    "target_temp": "Default target temperature",
+                    "target_temp_high": "Default upper target (Heat/Cool mode)",
+                    "target_temp_low": "Default lower target (Heat/Cool mode)",
+                    "min_temp": "Minimum temperature",
+                    "max_temp": "Maximum temperature",
+                    "cold_tolerance": "Cold tolerance",
+                    "hot_tolerance": "Hot tolerance",
+                    "precision": "Precision",
+                    "target_temp_step": "Temperature step"
+                }
+            },
+            "timing": {
+                "title": "Timing & Modes",
+                "description": "Edit cycle timing, keep-alive, initial mode, and away temperatures.",
+                "data": {
+                    "min_cycle_duration": "Minimum cycle duration",
+                    "keep_alive": "Keep-alive interval",
+                    "initial_hvac_mode": "Initial HVAC mode",
+                    "away_temp": "Away temperature",
+                    "away_temp_heater": "Away temperature (heater)",
+                    "away_temp_cooler": "Away temperature (cooler)",
+                    "consent_entity": "Consent entity"
+                }
+            },
+            "water_guard": {
+                "title": "Water Temperature Guard",
+                "description": "Edit water supply temperature guard settings.",
+                "data": {
+                    "water_sensor": "Water temperature sensor",
+                    "water_setpoint_heat": "Water setpoint for heating",
+                    "water_setpoint_cool": "Water setpoint for cooling",
+                    "water_setpoint_heat_entity": "Water setpoint heat entity",
+                    "water_setpoint_cool_entity": "Water setpoint cool entity",
+                    "water_tolerance": "Water temperature tolerance"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/dualmode_generic/translations/en.json
+++ b/custom_components/dualmode_generic/translations/en.json
@@ -1,0 +1,137 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Base Configuration",
+                "description": "Configure the basic settings for the thermostat.",
+                "data": {
+                    "name": "Name",
+                    "target_sensor": "Temperature sensor",
+                    "target_humidity_sensor": "Humidity sensor (optional)"
+                }
+            },
+            "devices": {
+                "title": "Devices",
+                "description": "Configure the heating, cooling, fan, and dryer devices.",
+                "data": {
+                    "heater": "Heater switch",
+                    "cooler": "Cooler switch",
+                    "fan": "Fan switch",
+                    "fan_behavior": "Fan behavior",
+                    "dryer": "Dryer switch",
+                    "dryer_behavior": "Dryer behavior",
+                    "reverse_cycle": "Reverse cycle devices",
+                    "enable_heat_cool": "Enable Heat/Cool mode"
+                }
+            },
+            "temperature": {
+                "title": "Temperature & Control",
+                "description": "Configure temperature targets, limits, and tolerances.",
+                "data": {
+                    "target_temp": "Default target temperature",
+                    "target_temp_high": "Default upper target (Heat/Cool mode)",
+                    "target_temp_low": "Default lower target (Heat/Cool mode)",
+                    "min_temp": "Minimum temperature",
+                    "max_temp": "Maximum temperature",
+                    "cold_tolerance": "Cold tolerance",
+                    "hot_tolerance": "Hot tolerance",
+                    "precision": "Precision",
+                    "target_temp_step": "Temperature step"
+                }
+            },
+            "timing": {
+                "title": "Timing & Modes",
+                "description": "Configure cycle timing, keep-alive, initial mode, and away temperatures.",
+                "data": {
+                    "min_cycle_duration": "Minimum cycle duration",
+                    "keep_alive": "Keep-alive interval",
+                    "initial_hvac_mode": "Initial HVAC mode",
+                    "away_temp": "Away temperature",
+                    "away_temp_heater": "Away temperature (heater)",
+                    "away_temp_cooler": "Away temperature (cooler)",
+                    "consent_entity": "Consent entity"
+                }
+            },
+            "water_guard": {
+                "title": "Water Temperature Guard",
+                "description": "Configure water supply temperature guard to prevent operation when water is not at the required temperature.",
+                "data": {
+                    "water_sensor": "Water temperature sensor",
+                    "water_setpoint_heat": "Water setpoint for heating (min water temp to allow heating)",
+                    "water_setpoint_cool": "Water setpoint for cooling (max water temp to allow cooling)",
+                    "water_setpoint_heat_entity": "Water setpoint heat entity (overrides fixed value)",
+                    "water_setpoint_cool_entity": "Water setpoint cool entity (overrides fixed value)",
+                    "water_tolerance": "Water temperature tolerance"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Options",
+                "description": "Select a category to edit.",
+                "menu_options": {
+                    "devices": "Devices",
+                    "temperature": "Temperature & Control",
+                    "timing": "Timing & Modes",
+                    "water_guard": "Water Temperature Guard"
+                }
+            },
+            "devices": {
+                "title": "Devices",
+                "description": "Edit heating, cooling, fan, and dryer devices.",
+                "data": {
+                    "heater": "Heater switch",
+                    "cooler": "Cooler switch",
+                    "fan": "Fan switch",
+                    "fan_behavior": "Fan behavior",
+                    "dryer": "Dryer switch",
+                    "dryer_behavior": "Dryer behavior",
+                    "reverse_cycle": "Reverse cycle devices",
+                    "enable_heat_cool": "Enable Heat/Cool mode"
+                }
+            },
+            "temperature": {
+                "title": "Temperature & Control",
+                "description": "Edit temperature targets, limits, and tolerances.",
+                "data": {
+                    "target_temp": "Default target temperature",
+                    "target_temp_high": "Default upper target (Heat/Cool mode)",
+                    "target_temp_low": "Default lower target (Heat/Cool mode)",
+                    "min_temp": "Minimum temperature",
+                    "max_temp": "Maximum temperature",
+                    "cold_tolerance": "Cold tolerance",
+                    "hot_tolerance": "Hot tolerance",
+                    "precision": "Precision",
+                    "target_temp_step": "Temperature step"
+                }
+            },
+            "timing": {
+                "title": "Timing & Modes",
+                "description": "Edit cycle timing, keep-alive, initial mode, and away temperatures.",
+                "data": {
+                    "min_cycle_duration": "Minimum cycle duration",
+                    "keep_alive": "Keep-alive interval",
+                    "initial_hvac_mode": "Initial HVAC mode",
+                    "away_temp": "Away temperature",
+                    "away_temp_heater": "Away temperature (heater)",
+                    "away_temp_cooler": "Away temperature (cooler)",
+                    "consent_entity": "Consent entity"
+                }
+            },
+            "water_guard": {
+                "title": "Water Temperature Guard",
+                "description": "Edit water supply temperature guard settings.",
+                "data": {
+                    "water_sensor": "Water temperature sensor",
+                    "water_setpoint_heat": "Water setpoint for heating",
+                    "water_setpoint_cool": "Water setpoint for cooling",
+                    "water_setpoint_heat_entity": "Water setpoint heat entity",
+                    "water_setpoint_cool_entity": "Water setpoint cool entity",
+                    "water_tolerance": "Water temperature tolerance"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/dualmode_generic/translations/it.json
+++ b/custom_components/dualmode_generic/translations/it.json
@@ -1,0 +1,137 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Configurazione base",
+                "description": "Configura le impostazioni di base del termostato.",
+                "data": {
+                    "name": "Nome",
+                    "target_sensor": "Sensore di temperatura",
+                    "target_humidity_sensor": "Sensore di umidità (opzionale)"
+                }
+            },
+            "devices": {
+                "title": "Dispositivi",
+                "description": "Configura i dispositivi di riscaldamento, raffrescamento, ventilazione e deumidificazione.",
+                "data": {
+                    "heater": "Switch riscaldamento",
+                    "cooler": "Switch raffrescamento",
+                    "fan": "Switch ventilatore",
+                    "fan_behavior": "Comportamento ventilatore",
+                    "dryer": "Switch deumidificatore",
+                    "dryer_behavior": "Comportamento deumidificatore",
+                    "reverse_cycle": "Dispositivi a ciclo inverso",
+                    "enable_heat_cool": "Abilita modalità Caldo/Freddo"
+                }
+            },
+            "temperature": {
+                "title": "Temperature e Controllo",
+                "description": "Configura le temperature target, i limiti e le tolleranze.",
+                "data": {
+                    "target_temp": "Temperatura target predefinita",
+                    "target_temp_high": "Target superiore (modalità Caldo/Freddo)",
+                    "target_temp_low": "Target inferiore (modalità Caldo/Freddo)",
+                    "min_temp": "Temperatura minima",
+                    "max_temp": "Temperatura massima",
+                    "cold_tolerance": "Tolleranza freddo",
+                    "hot_tolerance": "Tolleranza caldo",
+                    "precision": "Precisione",
+                    "target_temp_step": "Step temperatura"
+                }
+            },
+            "timing": {
+                "title": "Temporizzazione e Modalità",
+                "description": "Configura la durata dei cicli, il keep-alive, la modalità iniziale e le temperature away.",
+                "data": {
+                    "min_cycle_duration": "Durata minima del ciclo",
+                    "keep_alive": "Intervallo keep-alive",
+                    "initial_hvac_mode": "Modalità HVAC iniziale",
+                    "away_temp": "Temperatura assenza",
+                    "away_temp_heater": "Temperatura assenza (riscaldamento)",
+                    "away_temp_cooler": "Temperatura assenza (raffrescamento)",
+                    "consent_entity": "Entità di consenso"
+                }
+            },
+            "water_guard": {
+                "title": "Guardia temperatura acqua",
+                "description": "Configura la guardia sulla temperatura di mandata dell'acqua per impedire il funzionamento quando l'acqua non è alla temperatura richiesta.",
+                "data": {
+                    "water_sensor": "Sensore temperatura acqua",
+                    "water_setpoint_heat": "Setpoint acqua riscaldamento (temp. minima acqua per scaldare)",
+                    "water_setpoint_cool": "Setpoint acqua raffrescamento (temp. massima acqua per raffreddare)",
+                    "water_setpoint_heat_entity": "Entità setpoint acqua riscaldamento (sovrascrive il valore fisso)",
+                    "water_setpoint_cool_entity": "Entità setpoint acqua raffrescamento (sovrascrive il valore fisso)",
+                    "water_tolerance": "Tolleranza temperatura acqua"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Opzioni",
+                "description": "Seleziona una categoria da modificare.",
+                "menu_options": {
+                    "devices": "Dispositivi",
+                    "temperature": "Temperature e Controllo",
+                    "timing": "Temporizzazione e Modalità",
+                    "water_guard": "Guardia temperatura acqua"
+                }
+            },
+            "devices": {
+                "title": "Dispositivi",
+                "description": "Modifica i dispositivi di riscaldamento, raffrescamento, ventilazione e deumidificazione.",
+                "data": {
+                    "heater": "Switch riscaldamento",
+                    "cooler": "Switch raffrescamento",
+                    "fan": "Switch ventilatore",
+                    "fan_behavior": "Comportamento ventilatore",
+                    "dryer": "Switch deumidificatore",
+                    "dryer_behavior": "Comportamento deumidificatore",
+                    "reverse_cycle": "Dispositivi a ciclo inverso",
+                    "enable_heat_cool": "Abilita modalità Caldo/Freddo"
+                }
+            },
+            "temperature": {
+                "title": "Temperature e Controllo",
+                "description": "Modifica le temperature target, i limiti e le tolleranze.",
+                "data": {
+                    "target_temp": "Temperatura target predefinita",
+                    "target_temp_high": "Target superiore (modalità Caldo/Freddo)",
+                    "target_temp_low": "Target inferiore (modalità Caldo/Freddo)",
+                    "min_temp": "Temperatura minima",
+                    "max_temp": "Temperatura massima",
+                    "cold_tolerance": "Tolleranza freddo",
+                    "hot_tolerance": "Tolleranza caldo",
+                    "precision": "Precisione",
+                    "target_temp_step": "Step temperatura"
+                }
+            },
+            "timing": {
+                "title": "Temporizzazione e Modalità",
+                "description": "Modifica la durata dei cicli, il keep-alive, la modalità iniziale e le temperature away.",
+                "data": {
+                    "min_cycle_duration": "Durata minima del ciclo",
+                    "keep_alive": "Intervallo keep-alive",
+                    "initial_hvac_mode": "Modalità HVAC iniziale",
+                    "away_temp": "Temperatura assenza",
+                    "away_temp_heater": "Temperatura assenza (riscaldamento)",
+                    "away_temp_cooler": "Temperatura assenza (raffrescamento)",
+                    "consent_entity": "Entità di consenso"
+                }
+            },
+            "water_guard": {
+                "title": "Guardia temperatura acqua",
+                "description": "Modifica le impostazioni della guardia sulla temperatura di mandata dell'acqua.",
+                "data": {
+                    "water_sensor": "Sensore temperatura acqua",
+                    "water_setpoint_heat": "Setpoint acqua riscaldamento",
+                    "water_setpoint_cool": "Setpoint acqua raffrescamento",
+                    "water_setpoint_heat_entity": "Entità setpoint acqua riscaldamento",
+                    "water_setpoint_cool_entity": "Entità setpoint acqua raffrescamento",
+                    "water_tolerance": "Tolleranza temperatura acqua"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces two major features to the Multi-Mode Generic Thermostat:

1. **Water Temperature Guard** — an optional guard that prevents heating/cooling devices from activating unless the water supply has reached the required temperature.
2. **Config Flow + Options Flow** — full UI-based setup and configuration editing, removing the need to use YAML.

Both features are fully backward-compatible with existing YAML-based configurations.

---

## Water Temperature Guard

Hydronic HVAC systems (radiant floors, fan coils, etc.) should not operate unless the water supply is at the appropriate temperature — running a heating valve when the boiler hasn't warmed the water wastes energy and provides no comfort benefit.

This feature adds two independent setpoints:

- `water_setpoint_heat`: heater activates only when `water_temp >= setpoint - tolerance` (water is hot enough)
- `water_setpoint_cool`: cooler activates only when `water_temp <= setpoint + tolerance` (water is cold enough)

Both setpoints support a fixed YAML value and/or a dynamic entity (`input_number`, `sensor`, etc.) for runtime adjustability. The entity value takes priority when configured.

### Configuration options added

| Key | Description |
|---|---|
| `water_sensor` | Entity ID of the water supply temperature sensor |
| `water_setpoint_heat` | Fixed threshold for heating mode |
| `water_setpoint_cool` | Fixed threshold for cooling mode |
| `water_setpoint_heat_entity` | Dynamic entity for heating threshold |
| `water_setpoint_cool_entity` | Dynamic entity for cooling threshold |
| `water_tolerance` | Dead-band tolerance (default: 0.3) |

### Behavior

- In `HEAT_COOL` mode, the guard is evaluated independently for each device
- When the guard blocks operation, `hvac_action` reports `idle`
- Extra state attributes are exposed: `water_temperature`, `water_setpoint_heat`, `water_setpoint_cool`, `water_guard_active`
- When the water temperature crosses the threshold, control logic is triggered automatically — no external automation needed

---

## Config Flow (UI-based setup)

Users can now configure the thermostat entirely from the Home Assistant UI:

**Settings → Devices & Services → Add Integration → Multi-Mode Generic Thermostat**

The setup wizard is structured in 5 sequential steps:

1. **Base** — name, temperature sensor, humidity sensor
2. **Devices** — heater, cooler, fan, dryer, behaviors, reverse cycle, heat_cool mode
3. **Temperature & Control** — targets, min/max, tolerances, precision, step
4. **Timing & Modes** — min cycle duration, keep-alive, initial mode, away temps, consent entity
5. **Water Guard** — water sensor, setpoints (heat/cool), setpoint entities, tolerance

The `unique_id` is auto-generated (UUID4) at creation time.

---

## Options Flow (runtime editing)

After creation, all parameters can be modified from the UI without restarting Home Assistant:

**Integration card → Configure**

A menu allows editing by category:
- Devices
- Temperature & Control
- Timing & Modes
- Water Temperature Guard

Changes are applied immediately via entry reload.

---

## Files changed

| File | Change |
|---|---|
| `climate.py` | Added water guard logic, `async_setup_entry` for config entries |
| `__init__.py` | Rewritten to support both YAML and config entry setup |
| `config_flow.py` | **New** — Config Flow (5 steps) + Options Flow (menu-based) |
| `manifest.json` | Added `config_flow: true`, bumped version to 0.3.0 |
| `strings.json` | **New** — English UI labels |
| `translations/en.json` | **New** — English translations |
| `translations/it.json` | **New** — Italian translations |
| `README.md` | Documented water guard feature with examples |

---

## Backward compatibility

- Existing YAML configurations continue to work without any changes
- The legacy `async_setup_platform` path is fully preserved
- No breaking changes to existing behavior

---

## Testing

- Verified correct activation/deactivation based on water temperature thresholds
- Verified `min_cycle_duration` interaction (guard check is respected, `force=True` bypasses cycle duration as expected)
- Verified Config Flow creates working entities with auto-generated unique IDs
- Verified Options Flow correctly merges changes and reloads the entry
